### PR TITLE
Add add_php_sapi_to_filename config

### DIFF
--- a/config/sql_logger.php
+++ b/config/sql_logger.php
@@ -36,4 +36,12 @@ return [
      * (by default it's in milliseconds)
      */
     'convert_to_seconds' => env('SQL_CONVERT_TIME_TO_SECONDS', false),
+
+    /**
+     * Whether PHP_SAPI name should to added to log filename.
+     * It is useful when you run artisan command doing some queries and you 
+     * want to log these queries to separate file
+     *
+     */
+    'add_php_sapi_to_filename' => env('SQL_ADD_PHP_SAPI', false),
 ];

--- a/src/Providers/ServiceProvider.php
+++ b/src/Providers/ServiceProvider.php
@@ -21,6 +21,7 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
         $override = $this->getOverrideStatus();
         $directory = $this->getLogDirectory();
         $convertToSeconds = $this->getConvertToSeconds();
+        $addPhpSapi = $this->getAddPhpSapi();
 
         // if any of logging type is enabled we will listen database to get all
         // executed queries
@@ -35,6 +36,7 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
                     $override,
                     $directory,
                     $convertToSeconds,
+                    $addPhpSapi,
                 ]);
 
             // listen to database queries
@@ -129,5 +131,16 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
     {
         return (bool)$this->app->config->get('sql_logger.convert_to_seconds',
             env('SQL_CONVERT_TIME_TO_SECONDS', false));
+    }
+
+    /**
+     * Whether PHP_SAPI name should to added to log filename
+     *
+     * @return bool
+     */
+    protected function getAddPhpSapi()
+    {
+        return (bool)$this->app->config->get('sql_logger.add_php_sapi_to_filename',
+            env('SQL_ADD_PHP_SAPI', false));
     }
 }

--- a/src/SqlLogger.php
+++ b/src/SqlLogger.php
@@ -54,6 +54,13 @@ class SqlLogger
     protected $convertToSeconds;
 
     /**
+     * Whether PHP_SAPI name should to added to log filename
+     *
+     * @var bool
+     */
+    protected $addPhpSapi;
+
+    /**
      * SqlLogger constructor.
      *
      * @param $app
@@ -63,6 +70,7 @@ class SqlLogger
      * @param $override
      * @param $directory
      * @param $convertToSeconds
+     * @param $addPhpSapi
      */
     public function __construct(
         $app,
@@ -71,7 +79,8 @@ class SqlLogger
         $slowLogTime,
         $override,
         $directory,
-        $convertToSeconds
+        $convertToSeconds,
+        $addPhpSapi
     ) {
         $this->app = $app;
         $this->logStatus = $logStatus;
@@ -80,6 +89,7 @@ class SqlLogger
         $this->override = $override;
         $this->directory = rtrim($directory, '\\/');
         $this->convertToSeconds = $convertToSeconds;
+        $this->addPhpSapi = $addPhpSapi;
     }
 
     /**
@@ -121,13 +131,15 @@ class SqlLogger
     {
         // save normal query to file if enabled
         if ($this->logStatus) {
-            $this->saveLog($data, date('Y-m-d') . '-log.sql',
+            $this->saveLog($data, date('Y-m-d') . 
+                ($this->addPhpSapi ? '-' . php_sapi_name() : '') . '-log.sql',
                 ($queryNr == 1 && (bool)$this->override));
         }
 
         // save slow query to file if enabled
         if ($this->slowLogStatus && $execTime >= $this->slowLogTime) {
-            $this->saveLog($data, date('Y-m-d') . '-slow-log.sql');
+            $this->saveLog($data, date('Y-m-d') .
+                ($this->addPhpSapi ? '-' . php_sapi_name() : '') . '-slow-log.sql');
         }
     }
 


### PR DESCRIPTION
I add `add_php_sapi_to_filename` config to separate log files according to `php_sapi_name()`.

It would be helpful and be necessary when both console app and web app share the same log and encounters the file permission error. 
http://stackoverflow.com/questions/27674597/laravel-daily-log-created-with-wrong-permissions

Please consider it.
