### PR TITLE
fix: modify replaceBindings logic to fit current laravel implementation.

### DIFF
--- a/src/Objects/Concerns/ReplacesBindings.php
+++ b/src/Objects/Concerns/ReplacesBindings.php
@@ -19,7 +19,7 @@ trait ReplacesBindings
         $generalRegex = $this->getRegex();
 
         foreach ($this->formatBindings($bindings) as $key => $binding) {
-            $regex = is_numeric($key) ? $generalRegex : $this->getNamedParameterRegex($key);
+            $regex = is_int($key) ? $generalRegex : $this->getNamedParameterRegex($key);
             $sql = preg_replace($regex, $this->value($binding), $sql, 1);
         }
 
@@ -43,7 +43,7 @@ trait ReplacesBindings
             return (int) $value;
         }
 
-        return is_numeric($value) ? $value : "'" . $value . "'";
+        return is_int($value) ? $value : "'" . $value . "'";
     }
 
     /**

--- a/tests/Objects/SqlQueryTest.php
+++ b/tests/Objects/SqlQueryTest.php
@@ -53,7 +53,7 @@ EOF;
 
         $expectedSql = <<<EOF
 SELECT * FROM tests WHERE a = '\'test' AND CONCAT('{$bindings[1]->toDateTimeString()}', '%'
- , '{$bindings[2]->format('Y-m-d H:i:s')}') = 453 AND column = 67.23
+ , '{$bindings[2]->format('Y-m-d H:i:s')}') = 453 AND column = '67.23'
 EOF;
 
         $this->assertSame($expectedSql, $query->get());
@@ -72,7 +72,7 @@ EOF;
 
         $expectedSql = <<<EOF
 SELECT * FROM tests WHERE a = '\'test' AND CONCAT('{$bindings[1]->toDateTimeString()}', '%'
- , '{$bindings[2]->format('Y-m-d H:i:s')}') = 453 AND column = 67.23
+ , '{$bindings[2]->format('Y-m-d H:i:s')}') = 453 AND column = '67.23'
 EOF;
 
         $this->assertSame($expectedSql, $query->get());


### PR DESCRIPTION
Currently function `replaceBindings` logic is not same as Laravel (based [this](https://github.com/laravel/framework/blob/10.x/src/Illuminate/Database/Connection.php#L692))

```php
    public function bindValues($statement, $bindings)
    {
        foreach ($bindings as $key => $value) {
            $statement->bindValue(
                is_string($key) ? $key : $key + 1,
                $value,
                match (true) {
                    is_int($value) => PDO::PARAM_INT,
                    is_resource($value) => PDO::PARAM_LOB,
                    default => PDO::PARAM_STR
                },
            );
        }
    }
```
And use `is_numeric` also will transform `int string` to `int`, which is unexpected.

PS: With currently PHP PDO implementation ([url](https://www.php.net/manual/en/pdo.constants.php)), when binding parameter is decimal, you can use PDO::PARAM_STR instead (there is no such PDO::PARAM_DECIMAL)