### PR TITLE
Wrong parameter binding

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,11 +10,11 @@
         }
     ],
     "require": {
-        "illuminate/support": "5.*|6.*|7.*|8.*|9.*|10.*",
-        "mnabialek/laravel-version": "^1.0.6",
+        "illuminate/support": "5.*|6.*|7.*|8.*|9.*|10.*|11.*|12.*",
+        "mnabialek/laravel-version": "^v1.0.8",
         "nesbot/carbon": "~1.0 || ^2.0",
-        "illuminate/filesystem": "5.*|6.*|7.*|8.*|9.*|10.*",
-        "illuminate/container": "5.*|6.*|7.*|8.*|9.*|10.*"
+        "illuminate/filesystem": "5.*|6.*|7.*|8.*|9.*|10.*|11.*|12.*",
+        "illuminate/container": "5.*|6.*|7.*|8.*|9.*|10.*|11.*|12.*"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "illuminate/support": "5.*|6.*|7.*|8.*|9.*|10.*|11.*|12.*",
         "mnabialek/laravel-version": "^v1.0.8",
-        "nesbot/carbon": "~1.0 || ^2.0 || ^~3",
+        "nesbot/carbon": "~1.0 || ^2.0 || ^3",
         "illuminate/filesystem": "5.*|6.*|7.*|8.*|9.*|10.*|11.*|12.*",
         "illuminate/container": "5.*|6.*|7.*|8.*|9.*|10.*|11.*|12.*"
     },

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "illuminate/support": "5.*|6.*|7.*|8.*|9.*|10.*|11.*|12.*",
         "mnabialek/laravel-version": "^v1.0.8",
-        "nesbot/carbon": "~1.0 || ^2.0",
+        "nesbot/carbon": "~1.0 || ^2.0 || ^~3",
         "illuminate/filesystem": "5.*|6.*|7.*|8.*|9.*|10.*|11.*|12.*",
         "illuminate/container": "5.*|6.*|7.*|8.*|9.*|10.*|11.*|12.*"
     },

--- a/src/Objects/Concerns/ReplacesBindings.php
+++ b/src/Objects/Concerns/ReplacesBindings.php
@@ -16,6 +16,7 @@ trait ReplacesBindings
      */
     protected function replaceBindings($sql, array $bindings)
     {
+        $sql = str_replace('??&', '__qm_amp__', $sql);
         $generalRegex = $this->getRegex();
 
         foreach ($this->formatBindings($bindings) as $key => $binding) {
@@ -23,7 +24,7 @@ trait ReplacesBindings
             $sql = preg_replace($regex, $this->value($binding), $sql, 1);
         }
 
-        return $sql;
+        return str_replace('__qm_amp__', '?&', $sql);
     }
 
     /**
@@ -90,7 +91,7 @@ trait ReplacesBindings
     protected function getRegex()
     {
         return $this->wrapRegex(
-            $this->notInsideQuotes('?')
+            $this->notInsideQuotes('?[^$]')
             . '|' .
             $this->notInsideQuotes('[^:]\:\w+', false)
         );

--- a/src/Objects/Concerns/ReplacesBindings.php
+++ b/src/Objects/Concerns/ReplacesBindings.php
@@ -92,7 +92,7 @@ trait ReplacesBindings
         return $this->wrapRegex(
             $this->notInsideQuotes('?')
             . '|' .
-            $this->notInsideQuotes('\:\w+', false)
+            $this->notInsideQuotes('[^:]\:\w+', false)
         );
     }
 

--- a/src/Objects/Concerns/ReplacesBindings.php
+++ b/src/Objects/Concerns/ReplacesBindings.php
@@ -91,7 +91,7 @@ trait ReplacesBindings
     protected function getRegex()
     {
         return $this->wrapRegex(
-            $this->notInsideQuotes('?[^$]')
+            $this->notInsideQuotes('?')
             . '|' .
             $this->notInsideQuotes('[^:]\:\w+', false)
         );


### PR DESCRIPTION
When we have queries with casting like below

```php
Table::query()
  ->select()
  ->addSelect(DB::raw('x::text as x'))
  ->where('y', 'something');
```

then parameter binding is generating query like

```sql
SELECT *, x:'something' FROM table WHERE y = ?
```
